### PR TITLE
fix: 解决了项目创建后package.json乱序的问题

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.40"
 console = "0.15.5"
 termcolor = "1.2.0"
 regex = "1.7.3"
-serde = { version = "1.0.159", features = ["derive"]}
-serde_json = "1.0.95"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["preserve_order"] }
 serde_derive = "1.0.159"
 git2 = "0.18.1"


### PR DESCRIPTION
## 问题排查
乱序的代码根源：`serde_json::from_str(&new_contents)`
使用了serde_json其官方文档说了默认支持BTreeMap，所以本质上是这个玩意导致了生成的json乱序，为了修正这个问题官方给出了相应的解决方案就是使用IndexMap来替代它。使用的方式就是给serde_json加上feature,名字为preserve_order。

## 解决
Cargo.toml替换里头的serde_json一行为`serde_json = { version = "1.0.95", features = ["preserve_order"] }`以开启保持顺序的功能

## 效果
### 使用前
<img width="895" alt="截屏2023-11-06 21 34 47" src="https://github.com/laqudee/create-vue-monorepo-rs/assets/72691225/623cf7ec-ba0b-4c48-acf2-e04072d05542">

### 使用后
<img width="895" alt="截屏2023-11-06 21 34 40" src="https://github.com/laqudee/create-vue-monorepo-rs/assets/72691225/06824a32-cfac-4562-81d8-5fdfb015f2b2">

## 参考
https://docs.rs/serde_json/latest/serde_json/enum.Value.html

<img width="1034" alt="截屏2023-11-06 21 42 00" src="https://github.com/laqudee/create-vue-monorepo-rs/assets/72691225/3f69b33d-7dc9-45b8-8b76-fbd001388add">
